### PR TITLE
Authorization code

### DIFF
--- a/Player.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Player.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -31,10 +31,10 @@ namespace Player.Api.Infrastructure.Extensions
                 {
                     Type = SecuritySchemeType.OAuth2,
                     Flows = new OpenApiOAuthFlows
-                    {
-                        Implicit = new OpenApiOAuthFlow
-                        {
+                    {    
+                        AuthorizationCode = new OpenApiOAuthFlow {                            
                             AuthorizationUrl = new Uri(authOptions.AuthorizationUrl),
+                            TokenUrl = new Uri(authOptions.TokenUrl), 
                             Scopes = new Dictionary<string, string>()
                             {
                                 {authOptions.AuthorizationScope, "public api access"}

--- a/Player.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/Player.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -12,6 +12,7 @@ namespace Player.Api.Options
     {
         public string Authority { get; set; }
         public string AuthorizationUrl { get; set; }
+        public string TokenUrl { get; set; }
         public string AuthorizationScope { get; set; }
         public string ClientId { get; set; }
         public string ClientName { get; set; }

--- a/Player.Api/Startup.cs
+++ b/Player.Api/Startup.cs
@@ -196,6 +196,7 @@ namespace Player.Api
                 c.OAuthClientId(_authOptions.ClientId);
                 c.OAuthClientSecret(_authOptions.ClientSecret);
                 c.OAuthAppName(_authOptions.ClientName);
+                c.OAuthUsePkce();
             });
 
             app.UseAuthentication();

--- a/Player.Api/appsettings.json
+++ b/Player.Api/appsettings.json
@@ -38,6 +38,7 @@
   "Authorization": {
     "Authority": "http://localhost:5000",
     "AuthorizationUrl": "http://localhost:5000/connect/authorize",
+    "TokenUrl": "http://localhost:5000/connect/token",
     "AuthorizationScope": "player",
     "ClientId": "player.swagger",
     "ClientName": "Player Swagger UI",


### PR DESCRIPTION
### Security Fix

Change OAuth2 flow from `Implicit` to `Authorization Code` to follow best practices.

### Breaking Change
Need to add `TokenUrl` to the IdentityServer's `token` endpoint as an appsetting, and update the Client in Identity.

Addresses internal issue `CRU-1842`.