### PR TITLE
improve support for different identity providers

### DIFF
--- a/Player.Api/Infrastructure/ClaimsTransformers/AuthorizationClaimsTransformer.cs
+++ b/Player.Api/Infrastructure/ClaimsTransformers/AuthorizationClaimsTransformer.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Player.Api.Services;
+using Player.Api.Extensions;
 
 namespace Player.Api.Infrastructure.ClaimsTransformers
 {
@@ -19,7 +20,8 @@ namespace Player.Api.Infrastructure.ClaimsTransformers
 
         public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
         {
-            var user = await _claimsService.AddUserClaims(principal, true);
+            var user = principal.NormalizeScopeClaims();
+            user = await _claimsService.AddUserClaims(user, true);
             _claimsService.SetCurrentClaimsPrincipal(user);
             return user;
         }

--- a/Player.Api/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Player.Api/Infrastructure/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 
 namespace Player.Api.Extensions
@@ -12,6 +12,47 @@ namespace Player.Api.Extensions
         public static Guid GetId(this ClaimsPrincipal principal)
         {
             return Guid.Parse(principal.FindFirst("sub")?.Value);
+        }
+
+        /// <summary>
+        /// Normalize scope claims to handle array or single string
+        /// </summary>
+        public static ClaimsPrincipal NormalizeScopeClaims(this ClaimsPrincipal principal)
+        {
+            var identities = new List<ClaimsIdentity>();
+
+            foreach (var id in principal.Identities)
+            {
+                var identity = new ClaimsIdentity(id.AuthenticationType, id.NameClaimType, id.RoleClaimType);
+
+                foreach (var claim in id.Claims)
+                {
+                    if (claim.Type == "scope")
+                    {
+                        if (claim.Value.Contains(' '))
+                        {
+                            var scopes = claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                            foreach (var scope in scopes)
+                            {
+                                identity.AddClaim(new Claim("scope", scope, claim.ValueType, claim.Issuer));
+                            }
+                        }
+                        else
+                        {
+                            identity.AddClaim(claim);
+                        }
+                    }
+                    else
+                    {
+                        identity.AddClaim(claim);
+                    }
+                }
+
+                identities.Add(identity);
+            }
+
+            return new ClaimsPrincipal(identities);
         }
     }
 }

--- a/Player.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/Player.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -18,5 +18,7 @@ namespace Player.Api.Options
         public string ClientName { get; set; }
         public string ClientSecret { get; set; }
         public bool RequireHttpsMetadata { get; set; }
+        public bool ValidateAudience { get; set; }
+        public string[] ValidAudiences { get; set; }
     }
 }

--- a/Player.Api/appsettings.json
+++ b/Player.Api/appsettings.json
@@ -14,10 +14,7 @@
     }
   },
   "CorsPolicy": {
-    "Origins": [
-      "http://localhost:4301",
-      "http://localhost:4303"
-    ],
+    "Origins": ["http://localhost:4301", "http://localhost:4303"],
     "Methods": [],
     "Headers": [],
     "AllowAnyOrigin": false,
@@ -43,7 +40,9 @@
     "ClientId": "player.swagger",
     "ClientName": "Player Swagger UI",
     "ClientSecret": "",
-    "RequireHttpsMetadata": false
+    "RequireHttpsMetadata": false,
+    "ValidateAudience": true,
+    "ValidAudiences": [] // Defaults to AuthorizationScope if null or empty
   },
   "ClaimsTransformation": {
     "EnableCaching": true,
@@ -57,7 +56,16 @@
   "FileUpload": {
     "basePath": "player/files",
     "maxSize": "64000000",
-    "allowedExtensions": [".pdf", ".png", ".jpg", ".jpeg", ".doc", ".docx", ".gif", ".txt"]
+    "allowedExtensions": [
+      ".pdf",
+      ".png",
+      ".jpg",
+      ".jpeg",
+      ".doc",
+      ".docx",
+      ".gif",
+      ".txt"
+    ]
   },
   "ApplicationInsights": {
     "ConnectionString": ""


### PR DESCRIPTION
- support scope claims as array or single space-delimited string
- adds ValidateAudience and ValidAudiences settings
  - allows for more granular control of token validation settings
  - defaults to previous behavior