### PR TITLE
fixed openapi client generation

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -26,16 +26,25 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Build Package
+      - name: Generate swagger.json
         run: |
           cd ${{ steps.package_name.outputs.directory }}
-          dotnet tool restore
-          dotnet build -c Release /p:version=${{ github.event.inputs.clientVersion }}
 
-      - name: Run Swagger
-        run: |
-          cd ${{ steps.package_name.outputs.directory }}
-          dotnet swagger tofile --output ../${{ steps.package_name.outputs.name }}/swagger.json bin/Release/*/${{ steps.package_name.outputs.dll_name }}.dll v1
+          dotnet build -c Release /p:version=${{ github.event.inputs.clientVersion }}
+          dotnet $(ls bin/Release/*/Player.Api.dll) --urls=http://localhost:5000 --open-api-only=true &
+
+          # Store the process ID of the background job
+          API_PID=$!
+
+          echo "Waiting for API to start..."
+          sleep 15
+
+          # Download the swagger.json from the running API
+          curl --insecure http://localhost:5000/swagger/v1/swagger.json --output ../${{ steps.package_name.outputs.name }}/swagger.json
+
+          # Stop the background API process
+          kill $API_PID
+        shell: bash
 
       - name: Run NSwag
         run: |

--- a/Player.Api/Program.cs
+++ b/Player.Api/Program.cs
@@ -1,6 +1,8 @@
 // Copyright 2022 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+using System;
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
@@ -10,13 +12,17 @@ namespace Player.Api;
 
 public class Program
 {
-        public static void Main(string[] args)
+    public static void Main(string[] args)
+    {
+        var host = CreateWebHostBuilder(args).Build();
+
+        if (!args.Contains("--open-api-only=true"))
         {
-            CreateWebHostBuilder(args)
-                .Build()
-                .InitializeDatabase()
-                .Run();
+            host = host.InitializeDatabase();
         }
+
+        host.Run();
+    }
 
     public static IHostBuilder CreateWebHostBuilder(string[] args)
     {

--- a/Player.Api/Startup.cs
+++ b/Player.Api/Startup.cs
@@ -58,6 +58,8 @@ public class Startup
     // This method gets called by the runtime. Use this method to add services to the container.
     public void ConfigureServices(IServiceCollection services)
     {
+        var openApiOnly = Configuration.GetValue<bool>("open-api-only");
+
         // Add Azure Application Insights, if connection string is supplied
         string appInsights = Configuration["ApplicationInsights:ConnectionString"];
         if (!string.IsNullOrWhiteSpace(appInsights))
@@ -190,9 +192,16 @@ public class Startup
         services.AddScoped<IPrincipal>(p => p.GetService<IHttpContextAccessor>().HttpContext.User);
 
         services.AddSingleton<ConnectionCacheService>();
+
+
         services.AddSingleton<BackgroundWebhookService>();
-        services.AddSingleton<IHostedService>(x => x.GetService<BackgroundWebhookService>());
         services.AddSingleton<IBackgroundWebhookService>(x => x.GetService<BackgroundWebhookService>());
+
+        if (!openApiOnly)
+        {
+            services.AddSingleton<IHostedService>(x => x.GetService<BackgroundWebhookService>());
+        }
+
         services.AddHttpClient();
         services.AddSingleton<TelemetryService>();
         var metricsBuilder = services.AddOpenTelemetry()


### PR DESCRIPTION
swashbuckle cli was generating incomplete swagger.json, so we switched to standing up the full api and getting the swagger.json through curl. Added a command line flag --open-api-only=true to disable anything not needed for generating the swagger.json such as database connections