### PR TITLE
Accept caller-supplied IDs for View and Team creation

### DIFF
--- a/Player.Api/Features/Teams/Requests/Create.cs
+++ b/Player.Api/Features/Teams/Requests/Create.cs
@@ -31,6 +31,7 @@ public class Create
     [DataContract(Name = "CreateTeamCommand")]
     public record Command : IRequest<Team>
     {
+        public Guid? Id { get; set; }
         [JsonIgnore]
         public Guid ViewId { get; set; }
         public string Name { get; set; }
@@ -76,6 +77,10 @@ public class Create
                 throw new EntityNotFoundException<View>();
 
             var teamEntity = mapper.Map<TeamEntity>(request);
+            teamEntity.ViewId = viewEntity.Id;
+
+            if (request.Id.HasValue && request.Id.Value != Guid.Empty)
+                teamEntity.Id = request.Id.Value;
 
             if (!request.RoleId.HasValue)
             {
@@ -87,7 +92,7 @@ public class Create
                 teamEntity.RoleId = defaultRoleId;
             }
 
-            viewEntity.Teams.Add(teamEntity);
+            db.Teams.Add(teamEntity);
             await db.SaveChangesAsync(cancellationToken);
 
             logger.LogWarning($"Team {teamEntity.Name} ({teamEntity.Id}) in View {teamEntity.ViewId} created by {identityResolver.GetId()}");

--- a/Player.Api/Features/Views/Requests/Create.cs
+++ b/Player.Api/Features/Views/Requests/Create.cs
@@ -1,6 +1,7 @@
 // Copyright 2025 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -25,6 +26,7 @@ public class Create
     [DataContract(Name = "CreateViewCommand")]
     public record Command : IRequest<View>
     {
+        public Guid? Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
         public ViewStatus Status { get; set; }
@@ -62,6 +64,9 @@ public class Create
         public override async Task<View> HandleRequest(Command request, CancellationToken cancellationToken)
         {
             var viewEntity = mapper.Map<ViewEntity>(request);
+
+            if (request.Id.HasValue && request.Id.Value != Guid.Empty)
+                viewEntity.Id = request.Id.Value;
 
             var viewAdminRole = await db.TeamRoles
                 .Where(p => p.Name == roleOptions.DefaultViewCreatorRole)


### PR DESCRIPTION
Allows Blueprint integration to pass predetermined GUIDs when creating Player views and teams, enabling consistent ID references across services.