### PR TITLE
Add StringToBooleanConverter for Application fields

### DIFF
--- a/Player.Api/Features/Applications/Requests/Create.cs
+++ b/Player.Api/Features/Applications/Requests/Create.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -20,6 +21,7 @@ using Player.Api.Features.Views;
 using Player.Api.Infrastructure.Authorization;
 using Player.Api.Infrastructure.Endpoints;
 using Player.Api.Infrastructure.Exceptions;
+using Player.Api.Infrastructure.JsonConverters;
 
 namespace Player.Api.Features.Applications;
 
@@ -35,7 +37,10 @@ public class Create
 
         public string Icon { get; set; }
 
+        [JsonConverter(typeof(StringToBooleanConverter))]
         public bool? Embeddable { get; set; }
+
+        [JsonConverter(typeof(StringToBooleanConverter))]
         public bool? LoadInBackground { get; set; }
 
         [Required]

--- a/Player.Api/Infrastructure/JsonConverters/StringToBooleanConverter.cs
+++ b/Player.Api/Infrastructure/JsonConverters/StringToBooleanConverter.cs
@@ -1,0 +1,45 @@
+// Copyright 2025 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Player.Api.Infrastructure.JsonConverters;
+
+/// <summary>
+/// JSON converter that accepts both boolean and string representations of boolean values
+/// Allows "true"/"false" strings to be deserialized as booleans for backwards compatibility
+/// </summary>
+public class StringToBooleanConverter : JsonConverter<bool?>
+{
+    public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.True:
+                return true;
+            case JsonTokenType.False:
+                return false;
+            case JsonTokenType.String:
+                var stringValue = reader.GetString();
+                if (string.IsNullOrEmpty(stringValue))
+                    return null;
+                if (bool.TryParse(stringValue, out var boolValue))
+                    return boolValue;
+                throw new JsonException($"Unable to convert \"{stringValue}\" to boolean");
+            case JsonTokenType.Null:
+                return null;
+            default:
+                throw new JsonException($"Unexpected token type: {reader.TokenType}");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options)
+    {
+        if (value.HasValue)
+            writer.WriteBooleanValue(value.Value);
+        else
+            writer.WriteNullValue();
+    }
+}


### PR DESCRIPTION
Adds JSON converter to accept both boolean and string representations for Embeddable and LoadInBackground fields in CreateApplicationCommand. This provides backwards compatibility with Terraform provider v2.5 which sends these fields as strings ("true"/"false") instead of booleans.