### PR TITLE
Fix AllPermissions roles missing DB-only permissions

### DIFF
--- a/Player.Api/Services/UserClaimsService.cs
+++ b/Player.Api/Services/UserClaimsService.cs
@@ -200,13 +200,15 @@ public class UserClaimsService : IUserClaimsService
 
         roles = roles.Distinct().ToList();
 
+        var allSystemPermissionValues = await _context.Permissions.Select(x => x.Name).ToArrayAsync();
+
         foreach (var role in roles)
         {
             List<string> permissions;
 
             if (role.AllPermissions)
             {
-                permissions = Enum.GetValues<SystemPermission>().Select(x => x.ToString()).ToList();
+                permissions = allSystemPermissionValues.ToList();
             }
             else
             {


### PR DESCRIPTION
## Problem
Users with an AllPermissions (Administrator) role received 403 from vm.api network endpoints (`/api/views/{viewId}/networks`) despite holding all system permissions.

## Root cause
`UserClaimsService.GetPermissionClaims` expanded AllPermissions roles from the `SystemPermission` enum, which does not include the DB-seeded `ViewNetworks` / `ManageNetworks` permissions (nor any permission created at runtime via `POST permissions`).

## Fix
Expand AllPermissions roles from all `PermissionEntity` rows in the DB, matching the team-permission path that already uses `_context.TeamPermissions`.