### PR TITLE
Fix deletion of views with hidden files

### DIFF
--- a/Player.Api/Controllers/FileController.cs
+++ b/Player.Api/Controllers/FileController.cs
@@ -50,13 +50,14 @@ namespace Player.Api.Controllers
 
         /// <summary> Get all files in a view accessable to the calling user </summary>
         /// <param name="viewId">The id of the view</param>
+        /// <param name="includeAllViewFiles">Whether to include all files in the view instead of applying primary-team visibility.</param>
         /// <param name="ct"></param>
         [HttpGet("views/{viewId}/files")]
         [ProducesResponseType(typeof(IEnumerable<FileModel>), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "getViewFiles")]
-        public async Task<IActionResult> GetViewFiles(Guid viewId, CancellationToken ct)
+        public async Task<IActionResult> GetViewFiles(Guid viewId, CancellationToken ct, [FromQuery] bool includeAllViewFiles = false)
         {
-            var files = await _fileService.GetByViewAsync(viewId, ct);
+            var files = await _fileService.GetByViewAsync(viewId, includeAllViewFiles, ct);
             return Ok(files);
         }
 

--- a/Player.Api/Features/Views/Requests/Delete.cs
+++ b/Player.Api/Features/Views/Requests/Delete.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,11 +61,16 @@ public class Delete
             if (viewToDelete == null)
                 throw new EntityNotFoundException<View>();
 
-            // Delete files within this view
-            var files = await fileService.GetByViewAsync(request.Id, cancellationToken);
-            foreach (var fp in files)
+            // GetByViewAsync is filtered by the caller's team access. Deleting a view
+            // must remove every file row or the view's foreign key will block deletion.
+            var fileIds = await db.Files
+                .Where(f => f.View.Id == request.Id)
+                .Select(f => f.Id)
+                .ToListAsync(cancellationToken);
+
+            foreach (var fileId in fileIds)
             {
-                await fileService.DeleteAsync(fp.id, cancellationToken);
+                await fileService.DeleteAsync(fileId, cancellationToken);
             }
 
             db.Views.Remove(viewToDelete);

--- a/Player.Api/Services/FileService.cs
+++ b/Player.Api/Services/FileService.cs
@@ -27,7 +27,7 @@ namespace Player.Api.Services
     {
         Task<IEnumerable<FileModel>> UploadAsync(FileForm form, CancellationToken ct);
         Task<IEnumerable<FileModel>> GetAsync(CancellationToken ct);
-        Task<IEnumerable<FileModel>> GetByViewAsync(Guid viewId, CancellationToken ct);
+        Task<IEnumerable<FileModel>> GetByViewAsync(Guid viewId, bool includeAllViewFiles, CancellationToken ct);
         Task<IEnumerable<FileModel>> GetByTeamAsync(Guid teamId, CancellationToken ct);
         Task<FileModel> GetByIdAsync(Guid fileId, CancellationToken ct);
         Task<Tuple<FileStream, string>> DownloadAsync(Guid fileId, CancellationToken ct);
@@ -110,9 +110,34 @@ namespace Player.Api.Services
             return _mapper.Map<IEnumerable<FileModel>>(files);
         }
 
-        public async Task<IEnumerable<FileModel>> GetByViewAsync(Guid viewId, CancellationToken ct)
+        public async Task<IEnumerable<FileModel>> GetByViewAsync(Guid viewId, bool includeAllViewFiles, CancellationToken ct)
         {
-            var userId = _user.GetId();
+            if (includeAllViewFiles)
+            {
+                var viewExists = await _context.Views
+                    .AnyAsync(v => v.Id == viewId, ct);
+
+                if (!viewExists)
+                    throw new EntityNotFoundException<ViewEntity>();
+
+                if (!await _authorizationService.Authorize<ViewEntity>(
+                    viewId,
+                    [SystemPermission.ViewViews, SystemPermission.ManageViews],
+                    [ViewPermission.ViewView, ViewPermission.ManageView],
+                    [],
+                    ct))
+                {
+                    throw new ForbiddenException();
+                }
+
+                var allViewFiles = await _context.Files
+                    .Where(f => f.View.Id == viewId)
+                    .Include(f => f.View)
+                    .ToListAsync(ct);
+
+                return _mapper.Map<IEnumerable<FileModel>>(allViewFiles);
+            }
+
             var teams = await _teamService.GetByViewIdForCurrentUserAsync(viewId, ct);
             var accessable = new List<FileModel>();
 


### PR DESCRIPTION
## Summary

- Query all files belonging to a view directly from the database during deletion.
- Avoid filtering files by the administrator's team visibility.
- Continue using `FileService.DeleteAsync` to clean up database records and physical files.

## Root Cause

`GetByViewAsync` only returns files visible through the caller's team permissions. An administrator with global `ManageViews` permission could therefore leave hidden file records
behind.

PostgreSQL then rejected the view deletion with:

`23503: FK_files_views_view_id`

## Fix

The delete handler now queries file IDs using the view relationship:

```csharp
var fileIds = await db.Files
    .Where(f => f.View.Id == request.Id)
    .Select(f => f.Id)
    .ToListAsync(cancellationToken);
```
Each file is deleted before the view.